### PR TITLE
Add bottom margin on icons to horizontally level them with the title.

### DIFF
--- a/src/assets/scss/style.scss
+++ b/src/assets/scss/style.scss
@@ -53,6 +53,7 @@ body.dark-layout {
 
 .incident-list .icon {
 	height: 18px;
+	margin-bottom: 2px;
 }
 
 // .rdt_TableCell{


### PR DESCRIPTION
<img width="467" alt="Screen Shot 2022-02-02 at 5 44 25 PM" src="https://user-images.githubusercontent.com/98069629/152267714-6460cd18-b618-450b-811b-bd69be885e66.png">
