### PR TITLE
Align icons to the first line in the icon description.

### DIFF
--- a/src/assets/scss/style.scss
+++ b/src/assets/scss/style.scss
@@ -69,7 +69,6 @@ body.dark-layout {
 	display: flex;
 	flex-direction: row !important;
 	padding: 0px;
-	align-items: center;
 }
 
 .icon-description .icon {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/98069629/153329547-0d8345a0-dc56-4e9e-9042-8677356a5495.png)

(as per Jiayi's request)