### PR TITLE
#191, #193 Edit the placeholder and space of the table title

### DIFF
--- a/src/views/IncidentList.js
+++ b/src/views/IncidentList.js
@@ -126,7 +126,7 @@ const IncidentList = (props) => {
             <Input
                 className="mb-1"
                 type="text"
-                placeholder={t('search')}
+                placeholder={t('Search for the news ...')}
                 onChange={(value) => {
                     setSearchTerm(value)
                     setVisibleLimit(INCR_COUNT)

--- a/src/views/IncidentMap.css
+++ b/src/views/IncidentMap.css
@@ -4,6 +4,7 @@
     width: 700px;
     margin-left: auto;
     margin-right: auto;
+    margin-bottom: 30px;
 }
 
 @media screen and (max-width:992px) {


### PR DESCRIPTION
Before:
- placeholder
<img width="569" alt="Screenshot 2024-03-21 at 11 51 49" src="https://github.com/1thing-org/hatecrimetracker-frontend/assets/77877889/1917e083-01fc-4479-959b-9293bdc5c901">

- space of title
<img width="787" alt="Screenshot 2024-03-21 at 12 50 56" src="https://github.com/1thing-org/hatecrimetracker-frontend/assets/77877889/3a7f73d4-437c-47bd-b5fe-db6436d883a2">

After:
- placeholder
<img width="569" alt="Screenshot 2024-03-21 at 12 50 11" src="https://github.com/1thing-org/hatecrimetracker-frontend/assets/77877889/99516949-b8bb-47ef-a49d-68f98df47421">

- space of title
<img width="787" alt="Screenshot 2024-03-21 at 12 50 24" src="https://github.com/1thing-org/hatecrimetracker-frontend/assets/77877889/ff0985a7-3e1a-4504-b85e-d644c259edfc">
