### PR TITLE
Add IncidentEdit page

### DIFF
--- a/src/views/IncidentAdminList.js
+++ b/src/views/IncidentAdminList.js
@@ -1,151 +1,191 @@
-import React, { useState, useEffect, useContext } from 'react';
-import { Link } from 'react-router-dom';
-import { Table, Button } from 'reactstrap';
-import { UserContext } from '../providers/UserProvider';
-import { auth } from '../firebase';
-import './IncidentAdminList.css'; 
-
+import React, { useState, useEffect, useContext } from "react";
+import { Link } from "react-router-dom";
+import { Table, Button } from "reactstrap";
+import { UserContext } from "../providers/UserProvider";
+import { auth } from "../firebase";
+import "./IncidentAdminList.css";
+import IncidentEdit from "./IncidentEdit";
 
 const IncidentListPage = () => {
-    const user = useContext(UserContext) || { photoURL: '', displayName: 'Guest', email: 'guest@example.com' };
-    const [incidents, setIncidents] = useState([]);
-    const [currentPage, setCurrentPage] = useState(1);
-    const [totalPages, setTotalPages] = useState(1);
-    const [isSmallScreen, setIsSmallScreen] = useState(window.innerWidth < 768);
+	const user = useContext(UserContext) || { photoURL: "", displayName: "Guest", email: "guest@example.com" };
+	const [incidents, setIncidents] = useState([]);
+	const [currentPage, setCurrentPage] = useState(1);
+	const [totalPages, setTotalPages] = useState(1);
+	const [isSmallScreen, setIsSmallScreen] = useState(window.innerWidth < 768);
+	const [selectedIncident, setSelectedIncident] = useState(null);
 
-    useEffect(() => {
-        loadIncidents(currentPage);
+	useEffect(() => {
+		loadIncidents(currentPage);
 
-        const handleResize = () => {
-            setIsSmallScreen(window.innerWidth < 768);
-        };
+		const handleResize = () => {
+			setIsSmallScreen(window.innerWidth < 768);
+		};
 
-        window.addEventListener('resize', handleResize);
+		window.addEventListener("resize", handleResize);
 
-        return () => {
-            window.removeEventListener('resize', handleResize);
-        };
-    }, [currentPage]);
+		return () => {
+			window.removeEventListener("resize", handleResize);
+		};
+	}, [currentPage]);
 
-    const loadIncidents = async (page) => {
-        try {
-            const response = await fetch('/data.json');
-            const data = await response.json();
-            const startIndex = (page - 1) * 7;
-            const selectedIncidents = data.incidents.slice(startIndex, startIndex + 7);
-            setIncidents(selectedIncidents); 
-            setTotalPages(Math.ceil(data.incidents.length / 7));
-        } catch (error) {
-            console.error('Error loading incidents:', error);
-        }
-    };
+	const loadIncidents = async (page) => {
+		try {
+			const response = await fetch("/data.json");
+			const data = await response.json();
+			const startIndex = (page - 1) * 7;
+			const selectedIncidents = data.incidents.slice(startIndex, startIndex + 7);
+			setIncidents(selectedIncidents);
+			setTotalPages(Math.ceil(data.incidents.length / 7));
+		} catch (error) {
+			console.error("Error loading incidents:", error);
+		}
+	};
 
-    const handlePageChange = (page) => {
-        setCurrentPage(page);
-        loadIncidents(page);
-    }; 
+	const handlePageChange = (page) => {
+		setCurrentPage(page);
+		loadIncidents(page);
+	};
 
-    if (!user) {
-        return <div>Loading...</div>;  
-    }
+	const handleDetailClick = (incident) => {
+		setSelectedIncident(incident);
+	};
 
-    return (
-        <div className="incident-list-page-container">
-            <div className="incident-list-page">
-                {/* Admin Info */}
-                <div className="d-flex align-items-center admin-info">
-                    <div className="avatar">
-                        <img src={user.photoURL} alt="User Avatar" onError={(e) => e.target.style.backgroundColor = '#D9D9D9'} /> {/*storage format?*/}
-                    </div>
-                    <div className="user-info">
-                        <p className="custom-margin">Name: <span>{user.displayName}</span></p>
-                        <p className="custom-margin">ID: <span>{user.email}</span></p>
-                        <Link to="/home" onClick={() => auth.signOut()} className="signout">Sign Out</Link>
-                    </div>
-                </div>
-                <div className="d-flex">
-                    {/* Left Sidebar */}
-                    <div className="left-sidebar px-3">
-                        <nav className="nav flex-column">
-                            <div className="tab news">
-                                <div className="bullet"></div>
-                                <Link className="nav-link" to="/admin/news">News</Link>
-                                <i className="fas fa-angle-down fa-lg" style={{ color: '#d9d9d9' }}></i>
-                            </div>
-                            <div className="tab">
-                                <div className="bullet"></div>
-                                <Link className="nav-link" to="/admin/selfreport">Self-Report</Link>
-                                <i class="fas fa-angle-right fa-lg" style={{ color: '#d9d9d9' }}></i>
-                            </div>
-                        </nav>
-                    </div>
-                    {/* Main Content */}
-                    <div className="flex-grow-1  main-content">
-                        <div className="header-container">
-                            <h5>Self-Report Incidents</h5>
-                        </div>
-                        <div className="table-container">
-                            <div className="table-header-container">
-                                <Table>
-                                    <thead className="table-header">
-                                        <tr>
-                                            <th>Incident ID</th>
-                                            <th>Date</th>
-                                            <th>Location</th>
-                                            <th>Content</th>
-                                            <th>File</th>
-                                            <th>Status</th>
-                                            <th>Reviewer</th>
-                                            <th>Operation</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody className="table-body-container">
-                                    {incidents.map(incident => (
-                                            <tr key={incident.id}>
-                                                <td>{incident.id}</td>
-                                                <td>{incident.incident_time}</td>
-                                                <td>{incident.incident_location}</td>
-                                                <td className="content-cell" title={incident.content}>
-                                                    {incident.content.length > 0 ? `${incident.content.slice(0, isSmallScreen ? 10 : 85)}...` : incident.content}
-                                                </td>
-                                                <td>
-                                                    <div className="file-icons-container">
-                                                        <a href={incident.file_url} target="_blank" rel="noopener noreferrer" className="file-icon">
-                                                            <img src="/path/to/document-icon.png" alt="Document" />
-                                                        </a>
-                                                        <a href={incident.file_url} target="_blank" rel="noopener noreferrer" className="file-icon">
-                                                            <img src="/path/to/document-icon.png" alt="Document" />
-                                                        </a>
-                                                    </div>
-                                                </td>
-                                                <td>{incident.status}</td>
-                                                <td>{incident.reviewer}</td>
-                                                <td>
-                                                    <Button color="btn btn-detail" size="sm">Detail</Button>{' '}
-                                                    <Button color="btn btn-reject" size="sm">Reject</Button>
-                                                </td>
-                                            </tr>
-                                        ))}
-                                    </tbody>
-                                </Table>
-                            </div>
-                            <div className="pagination">
-                                <button disabled={currentPage <= 1} onClick={() => handlePageChange(currentPage - 1)}>
-                                    <i className="fa-solid fa-sharp fa-angle-left fa-xl" style={{ color: '#d9d9d9' }}></i>
-                                </button>
-                                <span className="page-info">
-                                    <span className="current-page">{currentPage}</span> / {totalPages}
-                                </span>
-                                <button disabled={currentPage >= totalPages} onClick={() => handlePageChange(currentPage + 1)}>
-                                    <i className="fa-solid fa-angle-right fa-xl" style={{ color: '#d9d9d9' }}></i>
-                                </button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    );
+	const handleBackClick = () => {
+		setSelectedIncident(null);
+	};
+
+	if (!user) {
+		return <div>Loading...</div>;
+	}
+
+	return (
+		<div className="incident-list-page-container">
+			<div className="incident-list-page">
+				{/* Admin Info */}
+				<div className="d-flex align-items-center admin-info">
+					<div className="avatar">
+						<img src={user.photoURL} alt="User Avatar" onError={(e) => (e.target.style.backgroundColor = "#D9D9D9")} />{" "}
+						{/*storage format?*/}
+					</div>
+					<div className="user-info">
+						<p className="custom-margin">
+							Name: <span>{user.displayName}</span>
+						</p>
+						<p className="custom-margin">
+							ID: <span>{user.email}</span>
+						</p>
+						<Link to="/home" onClick={() => auth.signOut()} className="signout">
+							Sign Out
+						</Link>
+					</div>
+				</div>
+				<div className="d-flex">
+					{/* Left Sidebar */}
+					<div className="left-sidebar px-3">
+						<nav className="nav flex-column">
+							<div className="tab news">
+								<div className="bullet"></div>
+								<Link className="nav-link" to="/admin/news">
+									News
+								</Link>
+								<i className="fas fa-angle-down fa-lg" style={{ color: "#d9d9d9" }}></i>
+							</div>
+							<div className="tab">
+								<div className="bullet"></div>
+								<Link className="nav-link" to="/admin/selfreport">
+									Self-Report
+								</Link>
+								<i class="fas fa-angle-right fa-lg" style={{ color: "#d9d9d9" }}></i>
+							</div>
+						</nav>
+					</div>
+					{/* Main Content */}
+					<div className="flex-grow-1  main-content">
+						{selectedIncident ? (
+							<IncidentEdit incident={selectedIncident} onBack={handleBackClick} />
+						) : (
+							<>
+								<div className="header-container">
+									<h5>Self-Report Incidents</h5>
+								</div>
+								<div className="table-container">
+									<div className="table-header-container">
+										<Table>
+											<thead className="table-header">
+												<tr>
+													<th>Incident ID</th>
+													<th>Date</th>
+													<th>Location</th>
+													<th>Content</th>
+													<th>File</th>
+													<th>Status</th>
+													<th>Reviewer</th>
+													<th>Operation</th>
+												</tr>
+											</thead>
+											<tbody className="table-body-container">
+												{incidents.map((incident) => (
+													<tr key={incident.id}>
+														<td>{incident.id}</td>
+														<td>{incident.incident_time}</td>
+														<td>{incident.incident_location}</td>
+														<td className="content-cell" title={incident.content}>
+															{incident.content.length > 0
+																? `${incident.content.slice(0, isSmallScreen ? 10 : 85)}...`
+																: incident.content}
+														</td>
+														<td>
+															<div className="file-icons-container">
+																<a
+																	href={incident.file_url}
+																	target="_blank"
+																	rel="noopener noreferrer"
+																	className="file-icon">
+																	<img src="/path/to/document-icon.png" alt="Document" />
+																</a>
+																<a
+																	href={incident.file_url}
+																	target="_blank"
+																	rel="noopener noreferrer"
+																	className="file-icon">
+																	<img src="/path/to/document-icon.png" alt="Document" />
+																</a>
+															</div>
+														</td>
+														<td>{incident.status}</td>
+														<td>{incident.reviewer}</td>
+														<td>
+															<Button color="btn btn-detail" size="sm" onClick={() => handleDetailClick(incident)}>
+																Detail
+															</Button>{" "}
+															<Button color="btn btn-reject" size="sm">
+																Reject
+															</Button>
+														</td>
+													</tr>
+												))}
+											</tbody>
+										</Table>
+									</div>
+									<div className="pagination">
+										<button disabled={currentPage <= 1} onClick={() => handlePageChange(currentPage - 1)}>
+											<i className="fa-solid fa-sharp fa-angle-left fa-xl" style={{ color: "#d9d9d9" }}></i>
+										</button>
+										<span className="page-info">
+											<span className="current-page">{currentPage}</span> / {totalPages}
+										</span>
+										<button disabled={currentPage >= totalPages} onClick={() => handlePageChange(currentPage + 1)}>
+											<i className="fa-solid fa-angle-right fa-xl" style={{ color: "#d9d9d9" }}></i>
+										</button>
+									</div>
+								</div>
+							</>
+						)}
+					</div>
+				</div>
+			</div>
+		</div>
+	);
 };
 
 export default IncidentListPage;

--- a/src/views/IncidentEdit.css
+++ b/src/views/IncidentEdit.css
@@ -1,0 +1,149 @@
+.incident-edit-container {
+	padding: 20px;
+	background-color: white;
+	border-radius: 5px;
+	color: black;
+}
+
+.incident-edit-container h2 {
+	margin-bottom: 20px;
+	color: black;
+}
+
+.file-list {
+	display: flex;
+	flex-direction: column;
+}
+
+.file-item {
+	display: flex;
+	align-items: center;
+	margin-bottom: 10px;
+	color: black;
+}
+
+.file-item span {
+	margin-left: 10px;
+	flex-grow: 1;
+	color: black;
+}
+
+.incident-edit-container label {
+	color: black;
+}
+
+.incident-edit-container .form-control {
+	background-color: white;
+	color: black;
+}
+
+.incident-edit-container .btn-save,
+.btn-cancel {
+	color: black;
+	box-shadow: 2px 3px 5px rgba(0, 0, 0, 0.3);
+	margin-top: 20px;
+	margin-right: 30px;
+	padding: 3px 6px;
+	font-weight: bold;
+	font-size: 13px;
+	width: 7%;
+	border: none;
+}
+.btn-save {
+	background-color: #80caff;
+}
+.btn-cancel {
+	background-color: #f7f7f7;
+}
+.preview {
+	background-color: white;
+	box-shadow: none;
+}
+
+.divider {
+	border-top: 2px solid #ced4da;
+	border-bottom: 2px solid #ced4da;
+	margin-top: 3%;
+	margin-bottom: 4%;
+	padding-top: 2%;
+	padding-bottom: 2%;
+}
+span {
+	color: #a4a9b3;
+}
+.textarea {
+	height: 100px;
+}
+.file-list {
+	display: flex;
+	flex-direction: column;
+	margin-top: 2%;
+	margin-bottom: 2%;
+}
+
+.file-item {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 10px;
+	margin-bottom: 10px;
+}
+
+.checkbox-container,
+.file-preview {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.file-item span {
+	display: flex;
+	align-items: center;
+	justify-content: flex-start;
+}
+
+.btn-link {
+	display: flex;
+	align-items: center;
+	justify-content: flex-start;
+	color: blue;
+	box-shadow: none;
+	text-decoration: none;
+}
+.file-item img,
+.file-item video {
+	max-width: 150px;
+	max-height: 150px;
+}
+.file-thumbnail {
+	max-width: 100px;
+	max-height: 100px;
+}
+
+.file-preview-image,
+.file-preview-video {
+	width: 100%;
+	height: 100%;
+	object-fit: contain;
+}
+
+.modal-custom {
+	max-width: 60%;
+	width: 60%;
+	height: 60%;
+}
+.modal-header-custom {
+	background-color: white;
+}
+
+.modal-header-custom .modal-title {
+	color: black !important;
+}
+
+.modal-body-custom {
+	width: 100%;
+	height: 100%;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+}

--- a/src/views/IncidentEdit.js
+++ b/src/views/IncidentEdit.js
@@ -1,0 +1,188 @@
+import React, { useState } from "react";
+import { Button, Form, FormGroup, Label, Input, Row, Col, Modal, ModalHeader, ModalBody } from "reactstrap";
+import "./IncidentEdit.css";
+
+const IncidentEdit = ({ incident }) => {
+	const [selectedFiles, setSelectedFiles] = useState(incident.files || []);
+	const [selectedPreviews, setSelectedPreviews] = useState([]);
+	const [status, setStatus] = useState("Pending");
+	const [modal, setModal] = useState(false);
+	const [previewFile, setPreviewFile] = useState(null);
+
+	const toggleModal = () => setModal(!modal);
+
+	const handleStatusChange = (event) => {
+		setStatus(event.target.value);
+	};
+
+	const handleFileChange = (event) => {
+		const files = Array.from(event.target.files);
+		setSelectedFiles(files);
+	};
+
+	const handlePreview = (file) => {
+		setPreviewFile(file);
+		toggleModal();
+	};
+
+	const handleCheckboxChange = (file) => {
+		setSelectedPreviews((prev) => {
+			if (prev.includes(file)) {
+				return prev.filter((item) => item !== file);
+			} else {
+				return [...prev, file];
+			}
+		});
+	};
+
+	const renderFilePreview = (file) => {
+		const fileURL = URL.createObjectURL(file);
+		if (file.type.startsWith("image/")) {
+			return <img src={fileURL} alt={file.name} className="file-thumbnail" />;
+		} else if (file.type.startsWith("video/")) {
+			return <video src={fileURL} controls className="file-thumbnail" />;
+		} else {
+			return <div className="file-placeholder"></div>;
+		}
+	};
+
+	const renderPreviewContent = () => {
+		if (!previewFile) return null;
+		const fileURL = URL.createObjectURL(previewFile);
+		if (previewFile.type.startsWith("image/")) {
+			return <img src={fileURL} alt={previewFile.name} className="file-preview-image" />;
+		} else if (previewFile.type.startsWith("video/")) {
+			return <video src={fileURL} controls className="file-preview-video" />;
+		} else {
+			return <div className="file-placeholder"></div>;
+		}
+	};
+
+	return (
+		<>
+			<div className="header-container">
+				<h5>Edit Incidents</h5>
+			</div>
+			<div className="incident-edit-container">
+				<Form>
+					<Row form>
+						<FormGroup>
+							<Label for="incidentID">Incident ID: </Label>
+							<span> #{incident.id}</span>
+						</FormGroup>
+					</Row>
+					<Row form>
+						<Col md={3}>
+							<FormGroup>
+								<Label for="incidentTime">Incident Time</Label>
+								<Input type="text" name="incidentTime" id="incidentTime" value={incident.time} />
+							</FormGroup>
+						</Col>
+						<Col md={3}>
+							<FormGroup>
+								<Label for="location">Location</Label>
+								<Input type="text" name="location" id="location" value={incident.location} />
+							</FormGroup>
+						</Col>
+						<Col md={6}>
+							<FormGroup>
+								<Label for="title">Title</Label>
+								<Input type="text" name="title" id="title" value={incident.title} />
+							</FormGroup>
+						</Col>
+					</Row>
+					<FormGroup>
+						<Label for="abstract">Abstract</Label>
+						<Input className="textarea" type="textarea" name="abstract" id="abstract" value={incident.abstract} />
+					</FormGroup>
+					<FormGroup>
+						<Label for="exampleFile">File:</Label>
+						<Input id="exampleFile" name="file" type="file" multiple onChange={handleFileChange} />
+						<div className="file-list">
+							{selectedFiles.map((file, index) => (
+								<div key={index} className="file-item">
+									<Col md={1} className="checkbox-container">
+										<Input
+											type="checkbox"
+											checked={selectedPreviews.includes(file)}
+											onChange={() => handleCheckboxChange(file)}
+										/>
+									</Col>
+									<Col md={2} className="file-preview">
+										{renderFilePreview(file)}
+									</Col>
+									<Col md={3}>
+										<span>{file.name}</span>
+									</Col>
+									<Col md={6} className="preview">
+										<Button color="link" onClick={() => handlePreview(file)}>
+											Preview
+										</Button>
+									</Col>
+								</div>
+							))}
+						</div>
+					</FormGroup>
+					<div className="divider">
+						<FormGroup>
+							<Label for="reviewBy">Reporter ID: </Label>
+							<span> 000001</span>
+						</FormGroup>
+
+						<FormGroup>
+							<Row form>
+								<Col md={3}>
+									<FormGroup>
+										<Label for="contactEmail">Contact Email</Label>
+										<Input type="email" name="contactEmail" id="contactEmail" value={incident.contact_email} />
+									</FormGroup>
+								</Col>
+								<Col md={3}>
+									<FormGroup>
+										<Label for="contactPhoneNumber">Contact Phone Number</Label>
+										<Input
+											type="text"
+											name="contactPhoneNumber"
+											id="contactPhoneNumber"
+											value={incident.contact_phone_number}
+										/>
+									</FormGroup>
+								</Col>
+							</Row>
+						</FormGroup>
+					</div>
+					<FormGroup>
+						<Label for="reviewBy">Review by: </Label>
+						<span> reviewer 1</span>
+					</FormGroup>
+					<Col md={2}>
+						<FormGroup>
+							<Label for="status">Current Status</Label>
+							<Input type="select" name="status" id="status" value={status} onChange={handleStatusChange}>
+								<option value="Pending">Pending</option>
+								<option value="Approved">Approved</option>
+								<option value="Rejected">Rejected</option>
+							</Input>
+						</FormGroup>
+					</Col>
+
+					<FormGroup>
+						<Label for="comment">Comment</Label>
+						<Input className="textarea" type="textarea" name="comment" id="comment" value={incident.comment} />
+					</FormGroup>
+					<Button className="btn-save">Save</Button>
+					<Button className="btn-cancel">Cancel</Button>
+				</Form>
+			</div>
+
+			<Modal isOpen={modal} toggle={toggleModal} className="modal-custom">
+				<ModalHeader className="modal-header-custom" toggle={toggleModal}>
+					File Preview
+				</ModalHeader>
+				<ModalBody className="modal-body-custom">{renderPreviewContent()}</ModalBody>
+			</Modal>
+		</>
+	);
+};
+
+export default IncidentEdit;

--- a/src/views/IncidentEdit.js
+++ b/src/views/IncidentEdit.js
@@ -74,25 +74,25 @@ const IncidentEdit = ({ incident }) => {
 					<Row form>
 						<Col md={3}>
 							<FormGroup>
-								<Label for="incidentTime">Incident Time</Label>
+								<Label for="incidentTime">Incident Time: </Label>
 								<Input type="text" name="incidentTime" id="incidentTime" value={incident.time} />
 							</FormGroup>
 						</Col>
 						<Col md={3}>
 							<FormGroup>
-								<Label for="location">Location</Label>
+								<Label for="location">Location:</Label>
 								<Input type="text" name="location" id="location" value={incident.location} />
 							</FormGroup>
 						</Col>
 						<Col md={6}>
 							<FormGroup>
-								<Label for="title">Title</Label>
+								<Label for="title">Title:</Label>
 								<Input type="text" name="title" id="title" value={incident.title} />
 							</FormGroup>
 						</Col>
 					</Row>
 					<FormGroup>
-						<Label for="abstract">Abstract</Label>
+						<Label for="abstract">Abstract:</Label>
 						<Input className="textarea" type="textarea" name="abstract" id="abstract" value={incident.abstract} />
 					</FormGroup>
 					<FormGroup>
@@ -133,13 +133,13 @@ const IncidentEdit = ({ incident }) => {
 							<Row form>
 								<Col md={3}>
 									<FormGroup>
-										<Label for="contactEmail">Contact Email</Label>
+										<Label for="contactEmail">Contact Email:</Label>
 										<Input type="email" name="contactEmail" id="contactEmail" value={incident.contact_email} />
 									</FormGroup>
 								</Col>
 								<Col md={3}>
 									<FormGroup>
-										<Label for="contactPhoneNumber">Contact Phone Number</Label>
+										<Label for="contactPhoneNumber">Contact Phone Number:</Label>
 										<Input
 											type="text"
 											name="contactPhoneNumber"
@@ -157,7 +157,7 @@ const IncidentEdit = ({ incident }) => {
 					</FormGroup>
 					<Col md={2}>
 						<FormGroup>
-							<Label for="status">Current Status</Label>
+							<Label for="status">Current Status:</Label>
 							<Input type="select" name="status" id="status" value={status} onChange={handleStatusChange}>
 								<option value="Pending">Pending</option>
 								<option value="Approved">Approved</option>
@@ -167,7 +167,7 @@ const IncidentEdit = ({ incident }) => {
 					</Col>
 
 					<FormGroup>
-						<Label for="comment">Comment</Label>
+						<Label for="comment">Comment:</Label>
 						<Input className="textarea" type="textarea" name="comment" id="comment" value={incident.comment} />
 					</FormGroup>
 					<Button className="btn-save">Save</Button>


### PR DESCRIPTION
Issue: #72 

Changes:
1. Create a new page to allow admin edit self-report incidents in the admin page
2. It allow admin to include or hide certain images/videos. 
(To test the page, I added a file upload button to show the image preview, it can be deleted when integration)

Page:
![Screenshot 2024-06-05 at 6 20 33 PM](https://github.com/1thing-org/hatecrimetracker-frontend/assets/113040940/2f9162f2-ba3c-4304-a9df-8a1916c5900d)
![Screenshot 2024-06-05 at 6 20 47 PM](https://github.com/1thing-org/hatecrimetracker-frontend/assets/113040940/e59f3cb6-95e9-45ac-b19a-3fbb5b049ffc)

Preview:
![Screenshot 2024-06-05 at 6 22 18 PM](https://github.com/1thing-org/hatecrimetracker-frontend/assets/113040940/e62c2173-c33b-4f31-a6fb-024b0c0176db)
![Screenshot 2024-06-05 at 6 22 55 PM](https://github.com/1thing-org/hatecrimetracker-frontend/assets/113040940/eb52bca2-0340-450b-b417-c70ea4e4cf14)
