### PR TITLE
Bug Fix Frontend UI White Spaces

### DIFF
--- a/src/views/IncidentAdminList.css
+++ b/src/views/IncidentAdminList.css
@@ -1,11 +1,3 @@
-html, body {
-    margin: 0;
-    padding: 0;
-    width: 100%;
-    height: 100%;
-    background-color: #ffffff; 
-}
-
 .incident-list-page-container {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
Fixes https://github.com/1thing-org/hatecrimetracker-frontend/issues/90

#### Reason of Bug  
The `html, body` block in `src/views/IncidentAdminList.css` was applying global styles that unintentionally affected other pages in the app (particularly the height and background-color part)

#### Fix Approach
Remove this block, since directly styling `html, body` inside a scoped css is not advised and can lead to global side effect. This is also tested that removing this CSS does not break the layout or functionality of the admin page.

https://github.com/user-attachments/assets/a888362e-447d-4ebc-bd0b-21f9ea975b64