### PR TITLE
[Chart UI] 1 - Support new backend API format for incident stats

### DIFF
--- a/src/assets/scss/style.scss
+++ b/src/assets/scss/style.scss
@@ -247,7 +247,7 @@ body.dark-layout {
 	background-color: #000000;
 	box-shadow: 0 4px 24px 0 rgba(34, 41, 47, 0.24); 
 	margin-bottom: .5rem;
-	margin-top: 1.2rem;
+	margin-top: 2rem;
 }
 
 .dark-layout .card-title {

--- a/src/configs/appConfig.js
+++ b/src/configs/appConfig.js
@@ -1,4 +1,4 @@
 export default {
-    api_endpoint: "http://192.168.86.234:8088/"
+    api_endpoint: "https://api.hatecrimetracker.1thing.org"
     //api_endpoint: "http://127.0.0.1:8081"
 };

--- a/src/configs/appConfig.js
+++ b/src/configs/appConfig.js
@@ -1,4 +1,4 @@
 export default {
-    api_endpoint: "https://api.hatecrimetracker.1thing.org"
+    api_endpoint: "http://192.168.86.234:8088/"
     //api_endpoint: "http://127.0.0.1:8081"
 };

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -81,92 +81,42 @@ const Home = () => {
     setSelectedLangCode(lang_code);
   };
 
-  // Normalize monthly stats to consistent format
-  const normalizeMonthlyStats = (stats) => {
-    if (!stats) return {};
 
-    return Object.fromEntries(
-      Object.entries(stats).map(([month, val]) => {
-        if (typeof val === "number") {
-          return [month, { news: val, self_report: 0 }];
-        } else {
-          return [
-            month,
-            {
-              news: val?.news || 0,
-              self_report: val?.self_report || 0,
-            },
-          ];
-        }
-      })
-    );
-  };
-
-  // stats [{'2021-01-02:1}, {'2021-01-01:1}...]
-  //   - Old format: Descending order
-  //   - New format: Ascending order
+  // "daily_statistics": {"2024-05-02": {"news": 1,"self_report": 0}},
   // Push each day from start_date to end_date, inserting missing days with default values
-  // Handles both old format (value field) and new format (news + self_report fields)
   // start_date, end_date: Date
-  // monthly: monthly aggregation { first_day_of_month: count_of_the_month }
-  //   - Old format: { '2024-01': 5 }
-  //   - New format: { '2024-01': {news: 3, self_report: 2} }
-  const mergeDate = (statsInput, start_date, end_date, monthly) => {
+  // monthly_statistics: { '2024-01': {news: 3, self_report: 2} }
+  const mergeDate = (dailyStats, start_date, end_date, monthly) => {
     const new_stats = [];
     let start = moment(start_date);
     const end = moment(end_date);
 
-    // Handle both old and new API formats for daily statistics
-    let stats = [];
-    if (Array.isArray(statsInput)) {
-      stats = statsInput;
-    } else if (typeof statsInput === 'object' && statsInput !== null) {
-      stats = Object.entries(statsInput).map(([key, value]) => ({
-        key,
-        news: value.news || 0,
-        self_report: value.self_report || 0,
-        value: value.news || 0
-      }));
-    }
-
-    // Convert stats object to a map for lookup
-    const statsMap = {}
-    stats.forEach(stat => {
-      statsMap[stat.key] = stat;
-    })
+    // use statsMap to store the daily stats
+    const statsMap = {};
+    Object.entries(dailyStats || {}).forEach(([date, stats]) => {
+      statsMap[date] = {
+        news: stats.news || 0,
+        self_report: stats.self_report || 0,
+      };
+    });
 
     while (start <= end) {
       const strDate = start.format("YYYY-MM-DD");
       const monthKey = start.format("YYYY-MM");
       const monthlyData = monthly[monthKey] || { news: 0, self_report: 0 };
-      const monthlyNews = monthlyData.news;
-      const monthlySelfReport = monthlyData.self_report;
+      const dailyStat = statsMap[strDate];
 
-      // Find the current date stats 
-      const dailyStat = statsMap[strDate]
-                      if (dailyStat) {
-          const dailyNews = dailyStat.news ?? dailyStat.value ?? 0;
-          const dailySelfReport = dailyStat.self_report ?? 0;
-          new_stats.push({
-            key: strDate,
-            daily_cases: dailyNews > 0 ? dailyNews : null,
-            daily_news: dailyNews,
-            daily_self_report: dailySelfReport,
-            monthly_cases: monthlyNews,
-            monthly_news: monthlyNews,
-            monthly_self_report: monthlySelfReport,
-          });
-        } else {
-          new_stats.push({
-            key: strDate,
-            daily_cases: null,
-            daily_news: 0,
-            daily_self_report: 0,
-            monthly_cases: monthlyNews,
-            monthly_news: monthlyNews,
-            monthly_self_report: monthlySelfReport,
-          });
-        }
+      // current only handle news
+      new_stats.push({
+        key: strDate,
+        daily_cases: dailyStat ? (dailyStat.news > 0 ? dailyStat.news : null) : null,
+        daily_news: dailyStat?.news || 0,
+        daily_self_report: dailyStat?.self_report || 0,
+        monthly_cases: monthlyData.news,
+        monthly_news: monthlyData.news,
+        monthly_self_report: monthlyData.self_report,
+      });
+
       start.add(1, "days");
     }
     console.log(new_stats)
@@ -189,36 +139,27 @@ const Home = () => {
           return;
         }
         
-        // Handle both old and new field names
-        const dailyStats = response.daily_statistics || response.stats || [];
-        const monthlyStatsRaw = response.monthly_statistics || response.monthly_stats || {};
-        const monthlyStats = normalizeMonthlyStats(monthlyStatsRaw);
-        const totalStats = response.insights || response.total || {};
+        // Handle new field names
+        const dailyStats = response.daily_statistics || {};
+        const monthlyStats = response.monthly_statistics || {};
+        const totalStats = response.insights || {};
         
-        const rawTimeSeries = mergeDate(
+        const timeSeries = mergeDate(
           dailyStats,
           dateRange[0],
           dateRange[1],
           monthlyStats
         );
 
-        
-        setIncidentTimeSeries(rawTimeSeries); 
+        setIncidentTimeSeries(timeSeries); 
         
         if (updateMap) {
-          // Convert new format objects to numbers for map/table compatibility
-          const processedTotalStats = {};
-          Object.entries(totalStats).forEach(([state, value]) => {
-            if (typeof value === "object" && value !== null) {
-              processedTotalStats[state] = value.news || 0;
-            } else if (typeof value === "number") {
-              processedTotalStats[state] = value;
-            } else {
-              processedTotalStats[state] = 0;
-            }
-          });
-          setIncidentAggregated(processedTotalStats);
-        }
+          const processedTotal = {};
+          Object.entries(totalStats).forEach(([state, data]) => {
+            processedTotal[state] = data?.news || 0;
+        });
+        setIncidentAggregated(processedTotal);
+      }
         setLoading(false);
         setIsFirstLoadData(false);
       });

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -312,7 +312,7 @@ const Home = () => {
     setSelectedState(newState);
   };
 
-  return (
+ return (
     <>
       {deviceSize < 786 && (
         <>
@@ -342,59 +342,47 @@ const Home = () => {
       <Head />
       <UILoader blocking={loading}>
         <div>
-          <Row>
-            <Col xs="12">
-              <Container className="header">
-                <Row className="align-items-center">
-                  <Col xs="12" sm="12" md="8">
-                    <p className="title">
-                      <img src={logo} alt="logo" className="logo" />{" "}
-                      {t("website.name")}
-                    </p>
-                  </Col>
+          <Container className="header">
+            <Row className="navbar align-items-center">
+              <Col xs="12" sm="12" md="8">
+                <p className="title">
+                  <img src={logo} alt="logo" className="logo" />{" "}
+                  {t("website.name")}
+                </p>
+              </Col>
 
-                  <Col xs="12" sm="12" md="4">
-                    <div className="OneRowItem d-flex align-items-center justify-content-md-end justify-content-xs-between justify-content-sm-between py-1">
-                      {deviceSize >= 786 && (
-                        <>
-                          <SocialMedia
-                            size={35}
-                            bgStyle={{ fill: "#000000" }}
-                            iconFillColor={"yellow"}
-                          />
-                          &nbsp;
-                          <button
-                            className="button-no-background"
-                            onClick={() => setIsShare(true)}
-                          >
-                            <RiShareForwardFill size={25} />
-                          </button>
-                          &nbsp;&nbsp;{" "}
-                        </>
-                      )}
-                      <a
-                        href="https://docs.google.com/forms/d/1pWp89Y6EThMHml1jYGkDj5J0YFO74K_37sIlOHKkWo0"
-                        target="_blank"
-                        className="contact_us"
-                      >
-                        {t("contact_us")}
-                      </a>
-                      &nbsp;&nbsp;&nbsp;&nbsp;
-                      <SelectPicker
-                        data={support_languages}
-                        searchable={false}
-                        cleanable={false}
-                        defaultValue={selectedLangCode}
-                        style={{ width: 120 }}
-                        className={"rs-theme-dark"}
-                        onChange={(value) => setSelectedLang(value)}
-                      />
-                    </div>
-                  </Col>
-                </Row>
+              <Col xs="12" sm="12" md="4">
+                <div className="OneRowItem right-controls d-flex align-items-center justify-content-md-end justify-content-xs-between justify-content-sm-between py-1">                      
+                  <ReportIncident />
+                  &nbsp;&nbsp;&nbsp;&nbsp;
+                  <a
+                    href="https://docs.google.com/forms/d/1pWp89Y6EThMHml1jYGkDj5J0YFO74K_37sIlOHKkWo0"
+                    target="_blank"
+                    className="contact_us"
+                  >
+                    {t("contact_us")}
+                  </a>
+                  &nbsp;&nbsp;&nbsp;&nbsp;
+                  <SelectPicker
+                    data={support_languages}
+                    searchable={false}
+                    cleanable={false}
+                    defaultValue={selectedLangCode}
+                    style={{ width: 120}}
+                    className={"rs-theme-dark no-border-lang-picker"}
+                    onChange={(value) => setSelectedLang(value)}
+                  />
+                </div>
+              </Col>
+            </Row> 
+          </Container>
+     
 
+          <Row className="match-height">
+            <Col xl="8" lg="6" md="12" className="left-panel">
+              <div className="left-panel-wrapper">
                 <FormGroup>
-                  <Row>
+                  <Row className="row-offset">
                     <Col xs="12" sm="12" md="auto" className="OneRowItem">
                       <Label className="SimpleLabel">{t("location")}:</Label>{" "}
                       <StateSelection
@@ -414,19 +402,20 @@ const Home = () => {
                     </Col>
                   </Row>
                 </FormGroup>
-              </Container>
-            </Col>
-          </Row>
-          <Row className="match-height">
-            <Col xl="8" lg="6" md="12">
-              <div>
                 <IncidentChart_AM
                   color={colors.primary.main}
                   chart_data={incidentTimeSeries}
                   state={selectedState}
                   isFirstLoadData={isFirstLoadData}
                 />
-
+                <div className="floating-social-media">
+                  <SocialMedia
+                    size={32}
+                    bgStyle={{ fill: "#1f2125" }}
+                    iconFillColor={"#FEF753"}
+                    isShare={false}
+                  />
+                </div>
                 <IncidentMap
                   mapData={incidentAggregated}
                   selectedState={selectedState}
@@ -442,7 +431,7 @@ const Home = () => {
                 />
               </div>
             </Col>
-            <Col xl="4" lg="6" md="12">
+            <Col xl="4" lg="6" md="12" className="right-panel">
               <Card>
                 {/* <CardHeader>
                             <CardTitle>Hate Crime Incidents</CardTitle>
@@ -454,7 +443,8 @@ const Home = () => {
             </Col>
           </Row>
         </div>
-        <div className="footer">
+        <div className="footer-wrapper">
+          <div className="footer">
           <Row>
             <Col sm="12" md={{ size: 6, offset: 3 }}>
               <Row>
@@ -495,6 +485,7 @@ const Home = () => {
               <li>{t("disclaimer.3")}</li>
             </ul>
           </div>
+        </div>
         </div>
       </UILoader>
     </>

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -1,4 +1,4 @@
- import UILoader from "./components/ui-loader";
+import UILoader from "./components/ui-loader";
 import logo from "../assets/images/logo/logo.png";
 import moment from "moment";
 import { useContext, useEffect, useState } from "react";
@@ -79,42 +79,76 @@ const Home = () => {
     setCookie("lang", lang_code);
     setSelectedLangCode(lang_code);
   };
-  // stats [{'2021-01-02:1}, {'2021-01-01:1}...]  dates descending
-  // Remove date out of the range, and insert days that does not have data
+
+  // stats [{'2021-01-02:1}, {'2021-01-01:1}...]
+  //   - Old format: Descending order
+  //   - New format: Ascending order
+  // Push each day from start_date to end_date, inserting missing days with default values
+  // Handles both old format (value field) and new format (news + self_report fields)
   // start_date, end_date: Date
   // monthly: monthly aggregation { first_day_of_month: count_of_the_month }
+  //   - Old format: { '2024-01': 5 }
+  //   - New format: { '2024-01': {news: 3, self_report: 2} }
   const mergeDate = (stats, start_date, end_date, monthly) => {
     const new_stats = [];
     let start = moment(start_date);
     const end = moment(end_date);
-    const strStartDate = start.format("YYYY-MM-DD");
-    const strEndDate = end.format("YYYY-MM-DD");
+    // Convert stats object to a map for lookup
+    const statsMap = {}
+    stats.forEach(stat => {
+      statsMap[stat.key] = stat;
+    })
+
     while (start <= end) {
       const strDate = start.format("YYYY-MM-DD");
-      const monthlyData = monthly[start.format("YYYY-MM")];
-      if (stats.length > 0) {
-        if (
-          stats[stats.length - 1].key < strStartDate ||
-          stats[stats.length - 1].key > strEndDate
-        ) {
-          stats.pop();
-          continue; //skip data that is out of range
-        }
-        if (stats[stats.length - 1].key == strDate) {
-          //found the date in stats, use it
-          new_stats.push({
-            monthly_cases: monthlyData,
-            ...stats[stats.length - 1],
-          });
-          stats.pop();
-          continue;
-        }
+      const monthKey = start.format("YYYY-MM");
+      const monthlyRaw = monthly[monthKey];
+
+      // Handle both old format (numbers) and new format (objects)
+      let monthlyNews = 0;
+      let monthlySelfReport = 0;
+      if (typeof monthlyRaw === "object" && monthlyRaw !== null) {
+        monthlyNews = monthlyRaw.news || 0;
+        monthlySelfReport = monthlyRaw.self_report || 0;
+      } else if (typeof monthlyRaw === "number") {
+        monthlyNews = monthlyRaw;
+        monthlySelfReport = 0;
       }
-      new_stats.push({ key: strDate, value: null, monthly_cases: monthlyData });
+
+      // Find the current date stats 
+      const dailyStat = statsMap[strDate]
+      if (dailyStat) {
+        let dailyValue;
+        if (dailyStat.value !== undefined) {
+          dailyValue = dailyStat.value;
+        } else {
+          dailyValue = dailyStat.news || 0;
+        }
+        new_stats.push({
+          key: strDate,
+          value: dailyValue > 0 ? dailyValue : null,
+          news: dailyStat.news || 0,
+          self_report: dailyStat.self_report || 0,
+          monthly_cases: monthlyNews,
+          monthly_news: monthlyNews,
+          monthly_self_report: monthlySelfReport,
+        });
+      } else {
+        new_stats.push({
+          key: strDate,
+          value: null,
+          news: 0,
+          self_report: 0,
+          monthly_cases: monthlyNews,
+          monthly_news: monthlyNews,
+          monthly_self_report: monthlySelfReport,
+        });
+      }
       start.add(1, "days");
     }
     return new_stats;
   };
+
   const loadData = (updateMap = false) => {
     if (dateRange?.length != 2) return;
 
@@ -144,9 +178,8 @@ const Home = () => {
   const generateUrl = (from, to, state, lang) => {
     return `/home?from=${moment(from).format("YYYY-MM-DD")}&to=${moment(
       to
-    ).format("YYYY-MM-DD")}${state ? "&state=" + state.toUpperCase() : ""}${
-      lang ? "&lang=" + lang : ""
-    }`;
+    ).format("YYYY-MM-DD")}${state ? "&state=" + state.toUpperCase() : ""}${lang ? "&lang=" + lang : ""
+      }`;
   };
 
   const isParameterChanged = () => {
@@ -186,9 +219,9 @@ const Home = () => {
       const defaultDateRange = isObjEmpty(searchParams.get("from"))
         ? [moment().subtract(1, "years").toDate(), new Date()]
         : [
-            moment(searchParams.get("from")).toDate(),
-            moment(searchParams.get("to")).toDate(),
-          ];
+          moment(searchParams.get("from")).toDate(),
+          moment(searchParams.get("to")).toDate(),
+        ];
 
       setSelectedState(getValidState(searchParams.get("state")));
       setDateRange(defaultDateRange);

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -178,8 +178,9 @@ const Home = () => {
   const generateUrl = (from, to, state, lang) => {
     return `/home?from=${moment(from).format("YYYY-MM-DD")}&to=${moment(
       to
-    ).format("YYYY-MM-DD")}${state ? "&state=" + state.toUpperCase() : ""}${lang ? "&lang=" + lang : ""
-      }`;
+    ).format("YYYY-MM-DD")}${state ? "&state=" + state.toUpperCase() : ""}${
+      lang ? "&lang=" + lang : ""
+    }`;
   };
 
   const isParameterChanged = () => {
@@ -219,9 +220,9 @@ const Home = () => {
       const defaultDateRange = isObjEmpty(searchParams.get("from"))
         ? [moment().subtract(1, "years").toDate(), new Date()]
         : [
-          moment(searchParams.get("from")).toDate(),
-          moment(searchParams.get("to")).toDate(),
-        ];
+            moment(searchParams.get("from")).toDate(),
+            moment(searchParams.get("to")).toDate(),
+          ];
 
       setSelectedState(getValidState(searchParams.get("state")));
       setDateRange(defaultDateRange);

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -144,31 +144,32 @@ const Home = () => {
 
       // Find the current date stats 
       const dailyStat = statsMap[strDate]
-      if (dailyStat) {
-        const dailyNews = dailyStat.news ?? dailyStat.value ?? 0;
-        const dailySelfReport = dailyStat.self_report ?? 0;
-        new_stats.push({
-          key: strDate,
-          value: dailyNews > 0 ? dailyNews : null,
-          daily_news: dailyStat.news || 0,
-          daily_self_report: dailyStat.self_report || 0,
-          monthly_cases: monthlyNews,
-          monthly_news: monthlyNews,
-          monthly_self_report: monthlySelfReport,
-        });
-      } else {
-        new_stats.push({
-          key: strDate,
-          value: null,
-          daily_news: 0,
-          daily_self_report: 0,
-          monthly_cases: monthlyNews,
-          monthly_news: monthlyNews,
-          monthly_self_report: monthlySelfReport,
-        });
-      }
+                      if (dailyStat) {
+          const dailyNews = dailyStat.news ?? dailyStat.value ?? 0;
+          const dailySelfReport = dailyStat.self_report ?? 0;
+          new_stats.push({
+            key: strDate,
+            daily_cases: dailyNews > 0 ? dailyNews : null,
+            daily_news: dailyNews,
+            daily_self_report: dailySelfReport,
+            monthly_cases: monthlyNews,
+            monthly_news: monthlyNews,
+            monthly_self_report: monthlySelfReport,
+          });
+        } else {
+          new_stats.push({
+            key: strDate,
+            daily_cases: null,
+            daily_news: 0,
+            daily_self_report: 0,
+            monthly_cases: monthlyNews,
+            monthly_news: monthlyNews,
+            monthly_self_report: monthlySelfReport,
+          });
+        }
       start.add(1, "days");
     }
+    console.log(new_stats)
     return new_stats;
   };
 

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -119,7 +119,6 @@ const Home = () => {
 
       start.add(1, "days");
     }
-    console.log(new_stats)
     return new_stats;
   };
 
@@ -143,7 +142,13 @@ const Home = () => {
         const dailyStats = response.daily_statistics || {};
         const monthlyStats = response.monthly_statistics || {};
         const totalStats = response.insights || {};
-        
+
+
+        // // Fall back strategy: Prefer new format, fallback to old format (remove if no needed)
+        // const dailyStats = response.daily_statistics || convertOldStats(response.stats);
+        // const monthlyStats = response.monthly_statistics || convertOldMonthlyStats(response.monthly_stats);
+        // const totalStats = response.insights || convertOldTotalStats(response.total);
+          
         const timeSeries = mergeDate(
           dailyStats,
           dateRange[0],
@@ -164,6 +169,28 @@ const Home = () => {
         setIsFirstLoadData(false);
       });
   };
+
+  // Helper functions to convert old format to new format (remove if no needed)
+  // const convertOldStats = (oldStats) => {
+  //   if (!oldStats) return {};
+  //   return Object.fromEntries(
+  //     oldStats.map(item => [item.key, {news: item.value || 0, self_report: 0}])
+  //   );
+  // };
+
+  // const convertOldMonthlyStats = (oldMonthly) => {
+  //   if (!oldMonthly) return {};
+  //   return Object.fromEntries(
+  //     Object.entries(oldMonthly).map(([month, value]) => [month, {news: value || 0, self_report: 0}])
+  //   );
+  // };
+
+  // const convertOldTotalStats = (oldTotal) => {
+  //   if (!oldTotal) return {};
+  //   return Object.fromEntries(
+  //     Object.entries(oldTotal).map(([state, value]) => [state, {news: value || 0, self_report: 0}])
+  //   );
+  // };
 
   const generateUrl = (from, to, state, lang) => {
     return `/home?from=${moment(from).format("YYYY-MM-DD")}&to=${moment(

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -81,6 +81,27 @@ const Home = () => {
     setSelectedLangCode(lang_code);
   };
 
+  // Normalize monthly stats to consistent format
+  const normalizeMonthlyStats = (stats) => {
+    if (!stats) return {};
+
+    return Object.fromEntries(
+      Object.entries(stats).map(([month, val]) => {
+        if (typeof val === "number") {
+          return [month, { news: val, self_report: 0 }];
+        } else {
+          return [
+            month,
+            {
+              news: val?.news || 0,
+              self_report: val?.self_report || 0,
+            },
+          ];
+        }
+      })
+    );
+  };
+
   // stats [{'2021-01-02:1}, {'2021-01-01:1}...]
   //   - Old format: Descending order
   //   - New format: Ascending order
@@ -90,10 +111,24 @@ const Home = () => {
   // monthly: monthly aggregation { first_day_of_month: count_of_the_month }
   //   - Old format: { '2024-01': 5 }
   //   - New format: { '2024-01': {news: 3, self_report: 2} }
-  const mergeDate = (stats, start_date, end_date, monthly) => {
+  const mergeDate = (statsInput, start_date, end_date, monthly) => {
     const new_stats = [];
     let start = moment(start_date);
     const end = moment(end_date);
+
+    // Handle both old and new API formats for daily statistics
+    let stats = [];
+    if (Array.isArray(statsInput)) {
+      stats = statsInput;
+    } else if (typeof statsInput === 'object' && statsInput !== null) {
+      stats = Object.entries(statsInput).map(([key, value]) => ({
+        key,
+        news: value.news || 0,
+        self_report: value.self_report || 0,
+        value: value.news || 0
+      }));
+    }
+
     // Convert stats object to a map for lookup
     const statsMap = {}
     stats.forEach(stat => {
@@ -103,33 +138,20 @@ const Home = () => {
     while (start <= end) {
       const strDate = start.format("YYYY-MM-DD");
       const monthKey = start.format("YYYY-MM");
-      const monthlyRaw = monthly[monthKey];
-
-      // Handle both old format (numbers) and new format (objects)
-      let monthlyNews = 0;
-      let monthlySelfReport = 0;
-      if (typeof monthlyRaw === "object" && monthlyRaw !== null) {
-        monthlyNews = monthlyRaw.news || 0;
-        monthlySelfReport = monthlyRaw.self_report || 0;
-      } else if (typeof monthlyRaw === "number") {
-        monthlyNews = monthlyRaw;
-        monthlySelfReport = 0;
-      }
+      const monthlyData = monthly[monthKey] || { news: 0, self_report: 0 };
+      const monthlyNews = monthlyData.news;
+      const monthlySelfReport = monthlyData.self_report;
 
       // Find the current date stats 
       const dailyStat = statsMap[strDate]
       if (dailyStat) {
-        let dailyValue;
-        if (dailyStat.value !== undefined) {
-          dailyValue = dailyStat.value;
-        } else {
-          dailyValue = dailyStat.news || 0;
-        }
+        const dailyNews = dailyStat.news ?? dailyStat.value ?? 0;
+        const dailySelfReport = dailyStat.self_report ?? 0;
         new_stats.push({
           key: strDate,
-          value: dailyValue > 0 ? dailyValue : null,
-          news: dailyStat.news || 0,
-          self_report: dailyStat.self_report || 0,
+          value: dailyNews > 0 ? dailyNews : null,
+          daily_news: dailyStat.news || 0,
+          daily_self_report: dailyStat.self_report || 0,
           monthly_cases: monthlyNews,
           monthly_news: monthlyNews,
           monthly_self_report: monthlySelfReport,
@@ -138,8 +160,8 @@ const Home = () => {
         new_stats.push({
           key: strDate,
           value: null,
-          news: 0,
-          self_report: 0,
+          daily_news: 0,
+          daily_self_report: 0,
           monthly_cases: monthlyNews,
           monthly_news: monthlyNews,
           monthly_self_report: monthlySelfReport,
@@ -159,17 +181,42 @@ const Home = () => {
       .then((incidents) => setIncidents(incidents));
     incidentsService
       .getStats(dateRange[0], dateRange[1], selectedState)
-      .then((stats) => {
-        setIncidentTimeSeries(
-          mergeDate(
-            stats.stats,
-            dateRange[0],
-            dateRange[1],
-            stats.monthly_stats
-          )
+      .then((response) => {
+        // Defensive check for malformed response
+        if (!response || typeof response !== "object") {
+          setLoading(false);
+          return;
+        }
+        
+        // Handle both old and new field names
+        const dailyStats = response.daily_statistics || response.stats || [];
+        const monthlyStatsRaw = response.monthly_statistics || response.monthly_stats || {};
+        const monthlyStats = normalizeMonthlyStats(monthlyStatsRaw);
+        const totalStats = response.insights || response.total || {};
+        
+        const rawTimeSeries = mergeDate(
+          dailyStats,
+          dateRange[0],
+          dateRange[1],
+          monthlyStats
         );
+
+        
+        setIncidentTimeSeries(rawTimeSeries); 
+        
         if (updateMap) {
-          setIncidentAggregated(stats.total);
+          // Convert new format objects to numbers for map/table compatibility
+          const processedTotalStats = {};
+          Object.entries(totalStats).forEach(([state, value]) => {
+            if (typeof value === "object" && value !== null) {
+              processedTotalStats[state] = value.news || 0;
+            } else if (typeof value === "number") {
+              processedTotalStats[state] = value;
+            } else {
+              processedTotalStats[state] = 0;
+            }
+          });
+          setIncidentAggregated(processedTotalStats);
         }
         setLoading(false);
         setIsFirstLoadData(false);
@@ -265,8 +312,6 @@ const Home = () => {
     setSelectedState(newState);
   };
 
-
-
   return (
     <>
       {deviceSize < 786 && (
@@ -297,47 +342,59 @@ const Home = () => {
       <Head />
       <UILoader blocking={loading}>
         <div>
-          <Container className="header">
-            <Row className="navbar align-items-center">
-              <Col xs="12" sm="12" md="8">
-                <p className="title">
-                  <img src={logo} alt="logo" className="logo" />{" "}
-                  {t("website.name")}
-                </p>
-              </Col>
+          <Row>
+            <Col xs="12">
+              <Container className="header">
+                <Row className="align-items-center">
+                  <Col xs="12" sm="12" md="8">
+                    <p className="title">
+                      <img src={logo} alt="logo" className="logo" />{" "}
+                      {t("website.name")}
+                    </p>
+                  </Col>
 
-              <Col xs="12" sm="12" md="4">
-                <div className="OneRowItem right-controls d-flex align-items-center justify-content-md-end justify-content-xs-between justify-content-sm-between py-1">                      
-                  <ReportIncident />
-                  &nbsp;&nbsp;&nbsp;&nbsp;
-                  <a
-                    href="https://docs.google.com/forms/d/1pWp89Y6EThMHml1jYGkDj5J0YFO74K_37sIlOHKkWo0"
-                    target="_blank"
-                    className="contact_us"
-                  >
-                    {t("contact_us")}
-                  </a>
-                  &nbsp;&nbsp;&nbsp;&nbsp;
-                  <SelectPicker
-                    data={support_languages}
-                    searchable={false}
-                    cleanable={false}
-                    defaultValue={selectedLangCode}
-                    style={{ width: 120}}
-                    className={"rs-theme-dark no-border-lang-picker"}
-                    onChange={(value) => setSelectedLang(value)}
-                  />
-                </div>
-              </Col>
-            </Row> 
-          </Container>
-     
+                  <Col xs="12" sm="12" md="4">
+                    <div className="OneRowItem d-flex align-items-center justify-content-md-end justify-content-xs-between justify-content-sm-between py-1">
+                      {deviceSize >= 786 && (
+                        <>
+                          <SocialMedia
+                            size={35}
+                            bgStyle={{ fill: "#000000" }}
+                            iconFillColor={"yellow"}
+                          />
+                          &nbsp;
+                          <button
+                            className="button-no-background"
+                            onClick={() => setIsShare(true)}
+                          >
+                            <RiShareForwardFill size={25} />
+                          </button>
+                          &nbsp;&nbsp;{" "}
+                        </>
+                      )}
+                      <a
+                        href="https://docs.google.com/forms/d/1pWp89Y6EThMHml1jYGkDj5J0YFO74K_37sIlOHKkWo0"
+                        target="_blank"
+                        className="contact_us"
+                      >
+                        {t("contact_us")}
+                      </a>
+                      &nbsp;&nbsp;&nbsp;&nbsp;
+                      <SelectPicker
+                        data={support_languages}
+                        searchable={false}
+                        cleanable={false}
+                        defaultValue={selectedLangCode}
+                        style={{ width: 120 }}
+                        className={"rs-theme-dark"}
+                        onChange={(value) => setSelectedLang(value)}
+                      />
+                    </div>
+                  </Col>
+                </Row>
 
-          <Row className="match-height">
-            <Col xl="8" lg="6" md="12" className="left-panel">
-              <div className="left-panel-wrapper">
                 <FormGroup>
-                  <Row className="row-offset">
+                  <Row>
                     <Col xs="12" sm="12" md="auto" className="OneRowItem">
                       <Label className="SimpleLabel">{t("location")}:</Label>{" "}
                       <StateSelection
@@ -357,20 +414,19 @@ const Home = () => {
                     </Col>
                   </Row>
                 </FormGroup>
+              </Container>
+            </Col>
+          </Row>
+          <Row className="match-height">
+            <Col xl="8" lg="6" md="12">
+              <div>
                 <IncidentChart_AM
                   color={colors.primary.main}
                   chart_data={incidentTimeSeries}
                   state={selectedState}
                   isFirstLoadData={isFirstLoadData}
                 />
-                <div className="floating-social-media">
-                  <SocialMedia
-                    size={32}
-                    bgStyle={{ fill: "#1f2125" }}
-                    iconFillColor={"#FEF753"}
-                    isShare={false}
-                  />
-                </div>
+
                 <IncidentMap
                   mapData={incidentAggregated}
                   selectedState={selectedState}
@@ -386,7 +442,7 @@ const Home = () => {
                 />
               </div>
             </Col>
-            <Col xl="4" lg="6" md="12" className="right-panel">
+            <Col xl="4" lg="6" md="12">
               <Card>
                 {/* <CardHeader>
                             <CardTitle>Hate Crime Incidents</CardTitle>
@@ -398,8 +454,7 @@ const Home = () => {
             </Col>
           </Row>
         </div>
-        <div className="footer-wrapper">
-          <div className="footer">
+        <div className="footer">
           <Row>
             <Col sm="12" md={{ size: 6, offset: 3 }}>
               <Row>
@@ -440,7 +495,6 @@ const Home = () => {
               <li>{t("disclaimer.3")}</li>
             </ul>
           </div>
-        </div>
         </div>
       </UILoader>
     </>

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -81,7 +81,6 @@ const Home = () => {
     setSelectedLangCode(lang_code);
   };
 
-
   // "daily_statistics": {"2024-05-02": {"news": 1,"self_report": 0}},
   // Push each day from start_date to end_date, inserting missing days with default values
   // start_date, end_date: Date
@@ -142,13 +141,7 @@ const Home = () => {
         const dailyStats = response.daily_statistics || {};
         const monthlyStats = response.monthly_statistics || {};
         const totalStats = response.insights || {};
-
-
-        // // Fall back strategy: Prefer new format, fallback to old format (remove if no needed)
-        // const dailyStats = response.daily_statistics || convertOldStats(response.stats);
-        // const monthlyStats = response.monthly_statistics || convertOldMonthlyStats(response.monthly_stats);
-        // const totalStats = response.insights || convertOldTotalStats(response.total);
-          
+        
         const timeSeries = mergeDate(
           dailyStats,
           dateRange[0],
@@ -169,28 +162,6 @@ const Home = () => {
         setIsFirstLoadData(false);
       });
   };
-
-  // Helper functions to convert old format to new format (remove if no needed)
-  // const convertOldStats = (oldStats) => {
-  //   if (!oldStats) return {};
-  //   return Object.fromEntries(
-  //     oldStats.map(item => [item.key, {news: item.value || 0, self_report: 0}])
-  //   );
-  // };
-
-  // const convertOldMonthlyStats = (oldMonthly) => {
-  //   if (!oldMonthly) return {};
-  //   return Object.fromEntries(
-  //     Object.entries(oldMonthly).map(([month, value]) => [month, {news: value || 0, self_report: 0}])
-  //   );
-  // };
-
-  // const convertOldTotalStats = (oldTotal) => {
-  //   if (!oldTotal) return {};
-  //   return Object.fromEntries(
-  //     Object.entries(oldTotal).map(([state, value]) => [state, {news: value || 0, self_report: 0}])
-  //   );
-  // };
 
   const generateUrl = (from, to, state, lang) => {
     return `/home?from=${moment(from).format("YYYY-MM-DD")}&to=${moment(

--- a/src/views/IncidentChart_AM.js
+++ b/src/views/IncidentChart_AM.js
@@ -98,8 +98,8 @@ const IncidentChart_AM = ({ color, chart_data, state, isFirstLoadData }) => {
     markerTemplate.children.getIndex(0).cornerRadius(0.5, 0.5, 0.5, 0.5);
     markerTemplate.width = 12;
     markerTemplate.height = 12;
-    series1.legendSettings.labelText = "Monthly Cases [bold {color}]{value}[/]";
-    series2.legendSettings.labelText = "Daily Cases [bold {color}]{value}[/]";
+    series1.legendSettings.labelText = "Monthly Cases";
+    series2.legendSettings.labelText = "Daily Cases";
 
     return () => {
       chart.dispose();

--- a/src/views/IncidentChart_AM.js
+++ b/src/views/IncidentChart_AM.js
@@ -34,6 +34,7 @@ const IncidentChart_AM = ({ color, chart_data, state, isFirstLoadData }) => {
 
     // Create chart instance
     let chart = am4core.create("chart_1yaxis", am4charts.XYChart);
+    chart.logo.disabled = true;
     chart.data = chart_data;
     // Create date axes and value axes
     let dateAxis = chart.xAxes.push(new am4charts.DateAxis());

--- a/src/views/IncidentChart_AM.js
+++ b/src/views/IncidentChart_AM.js
@@ -28,7 +28,7 @@ const IncidentChart_AM = ({ color, chart_data, state, isFirstLoadData }) => {
   useLayoutEffect(() => {
     let total = 0;
     for (let i = 0; i < chart_data.length; i++) {
-      total += chart_data[i].value;
+      total += chart_data[i].daily_cases || 0;  // Use daily_cases instead of value
     }
     setTotalCases(total);
 
@@ -74,12 +74,12 @@ const IncidentChart_AM = ({ color, chart_data, state, isFirstLoadData }) => {
     series1.fillOpacity = 0.4;
 
     let series2 = chart.series.push(new am4charts.ColumnSeries());
-    series2.dataFields.valueY = "value";
+    series2.dataFields.valueY = "daily_cases";
     series2.dataFields.dateX = "key";
     series2.name = "Daily Cases";
     // series2.tooltipText = toolTipText;
     series2.columns.template.tooltipText = `{key}
-        [bold]Daily Cases: {value}`;
+        [bold]Daily Cases: {daily_cases}`;
     chart.tooltip.label.fill = am4core.color("#f00");
     series2.clustered = true;
     series2.fill = am4core.color(color);


### PR DESCRIPTION
### Summary
- Part 1 of the Chart Support Self-report (self-report currently no showing in this pr). 
- Fixes the issue where the chart could not load backend data due to updated API format.

###  What’s Changed
- Frontend now expects **only the new API format** (`daily_statistics`, `monthly_statistics`, `insights`).
- Algorithm: HashMap lookup for simplicity, performance and maintainability
- Currently, the UI only displays **news** data; support for **self-reported** data will be added in a future PR.

###  Compatibility
- Since the backend is deployed first, frontend safely assumes the new format is available.

**When running backend data**
<img width="800" alt="chart-running-backend" src="https://github.com/user-attachments/assets/524da5fb-46c1-4d9a-b502-8d86ba17f959" />

###  Data Verified
- Confirmed that the processed data after `mergeDate()` is correctly structured and rendered.
- Daily and monthly breakdowns appear as expected, and the chart reflects **only news data** for both "Daily Cases" and "Monthly Cases" — aligned with the current UI design.

**Sample console output (now removed from final code) shows the merged structure**
<img width="800" alt="pushed-data" src="https://github.com/user-attachments/assets/6f929aca-5f90-47b6-85c9-3126409eed8a" />