### PR TITLE
Part 1 Incident list change: show image in incidentlist 

### DIFF
--- a/src/assets/scss/style.scss
+++ b/src/assets/scss/style.scss
@@ -6,7 +6,26 @@ body{
 body.dark-layout {
 	color: #b4b7bd;
 	background-color: #000000; }
-	
+
+.incident-list .source-tag {
+    display: block;
+    width: fit-content;
+    color: white;
+    padding: 2px 8px; 
+    border-radius: 4px;
+    font-size: 12px;
+    font-weight: 500;
+    margin-bottom: 8px;
+}
+
+.source-tag.user-report {
+    background-color: #E7734E;
+}
+
+.source-tag.news-report {
+    background-color: #002FBD;
+}
+
 .incident-list .incident-title {
 	font-family: Helvetica;
 	font-style: normal;
@@ -51,6 +70,16 @@ body.dark-layout {
 	line-height: 16px;
 	color: #FFFFFF;
 	margin-top: 8px;
+}
+
+.incident-divider {
+  height: 1px;
+  background: #3C3F43; 
+  margin: 30px 0 0; 
+  width: 100vw;
+  left:50%;
+  transform: translateX(-50%);      
+
 }
 
 .icon-description {

--- a/src/assets/scss/style.scss
+++ b/src/assets/scss/style.scss
@@ -11,9 +11,9 @@ body.dark-layout {
     display: block;
     width: fit-content;
     color: white;
-    padding: 2px 8px; 
+    padding: 2px 6px; 
     border-radius: 4px;
-    font-size: 12px;
+    font-size: 11px;
     font-weight: 500;
     margin-bottom: 8px;
 }

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -451,7 +451,8 @@ const Home = () => {
                             <CardTitle>Hate Crime Incidents</CardTitle>
                         </CardHeader> */}
                 <CardBody className="incident-list-card">
-                  <IncidentList data={incidents} />
+                  {/* Pass showSelfReport, so that when toggle on, news and self-report tag will show */}
+                  <IncidentList data={incidents} showSelfReport={showSelfReport} />
                 </CardBody>
               </Card>
             </Col>

--- a/src/views/IncidentList.js
+++ b/src/views/IncidentList.js
@@ -2,7 +2,7 @@ import Modal from 'react-modal';
 import moment from 'moment'
 import { useState, useEffect } from 'react'
 import { stateFullName } from '../utility/Utils.js'
-import { Button } from 'reactstrap'
+import { Button, Card, CardBody, Badge, Row, Col, CardImg } from 'reactstrap'
 import { useTranslation } from 'react-i18next';
 import { Input } from 'rsuite';
 import donationIcon from '../assets/images/icons/donation.svg';
@@ -139,21 +139,59 @@ const IncidentList = (props) => {
                         if (searchTerm === "" || getTitle(d).toLowerCase().includes(searchTerm.toLowerCase()) ||
                             getAbstract(d).toLowerCase().includes(searchTerm.toLowerCase())) {
                             visibleCount++;
-                            return (
-                                <div className='incident' key={idx}>
-                                    <a className='incident-title'
+
+                    // attachments
+                    const attachments = Array.isArray(d.attachments) ? d.attachments : [];
+                    const isUserReport = d.type === 'self_report';
+                  
+                    return (
+                        <div className="incident-card" key={idx}>
+                        <Card className="border-0 shadow-sm mx-0">
+                        <CardBody className="p-0">
+                            {/* Source Tag */}
+                        <div>
+                            <span className={`source-tag ${isUserReport ? 'user-report' : 'news-report'}`}>
+                                {isUserReport ? 'User Reported' : 'News Reported'}
+                            </span>
+                        </div>
+                            <a className='incident-title'
+                                onClick={() => {
+                                setModalData(d);
+                                openModal();
+                                }}>{getTitle(d)}</a>
+                            {maybeGetHelpIcons(d)}
+                            <p className='location-time'>
+                                {stateFullName(d.incident_location)} | {moment(d.incident_time).format('MM/DD/YYYY')}
+                            </p>
+                            <p className='description'>{getAbstract(d)}</p>
+                                {Array.isArray(d.attachments) && d.attachments.length > 0 && (
+                                <Row className="gx-2 gy-2 mt-2">
+                                    {d.attachments.map((url, i) => (
+                                    <Col xs="4" md="3" key={i}>
+                                        <CardImg
+                                        alt={`attachment-${i+1}`}
+                                        src={url}
+                                        style={{
+                                            aspectRatio: '1 / 1',
+                                            width: '100%',
+                                            objectFit: "cover",
+                                            cursor: "pointer"
+                                        }}
                                         onClick={() => {
                                             setModalData(d);
                                             openModal();
-                                        }}>{getTitle(d)}</a>
-                                    {maybeGetHelpIcons(d)}
-                                    <p className='location-time'>
-                                        {stateFullName(d.incident_location)} | {moment(d.incident_time).format('MM/DD/YYYY')}
-                                    </p>
-                                    <p className='description'>{getAbstract(d)}</p>
-                                </div>
-                            )
-                        }
+                                        }}
+                                        />
+                                    </Col>
+                                    ))}
+                                </Row>
+                                )}
+                        </CardBody>
+                    </Card>
+                    <div className="incident-divider" />
+                    </div>
+                    )
+                }
                         return "";
                     })
                 }

--- a/src/views/IncidentList.js
+++ b/src/views/IncidentList.js
@@ -2,7 +2,7 @@ import Modal from 'react-modal';
 import moment from 'moment'
 import { useState, useEffect } from 'react'
 import { stateFullName } from '../utility/Utils.js'
-import { Button, Card, CardBody, Badge, Row, Col, CardImg } from 'reactstrap'
+import { Button, Card, CardBody, Row, Col, CardImg } from 'reactstrap'
 import { useTranslation } from 'react-i18next';
 import { Input } from 'rsuite';
 import donationIcon from '../assets/images/icons/donation.svg';
@@ -121,6 +121,8 @@ const IncidentList = (props) => {
 
     const [searchTerm, setSearchTerm] = useState("")
 
+
+
     return (
         <div>
             <Input
@@ -134,14 +136,23 @@ const IncidentList = (props) => {
 
             <div className='incident-list'>
                 {
-                    props.data.map(function(d, idx) {
-                        if (searchTerm === "" && visibleCount >= visibleLimit) return "";
-                        if (searchTerm === "" || getTitle(d).toLowerCase().includes(searchTerm.toLowerCase()) ||
-                            getAbstract(d).toLowerCase().includes(searchTerm.toLowerCase())) {
-                            visibleCount++;
+                     props.data.map((d, idx) => {
+                        const normalizedSearch = (searchTerm || "").toLowerCase();
 
-                    // attachments
-                    const attachments = Array.isArray(d.attachments) ? d.attachments : [];
+                        // title might be empty
+                        const title = (getTitle(d) || "").toLowerCase();
+                        const abstract = (getAbstract(d) || "").toLowerCase();
+
+                        const matchesSearch =
+                            normalizedSearch === "" ||
+                            title.includes(normalizedSearch) ||
+                            abstract.includes(normalizedSearch);
+
+                        if (!matchesSearch) return null;
+
+                        if (normalizedSearch === "" && visibleCount >= visibleLimit) return null;
+                        visibleCount++;
+    
                     const isUserReport = d.type === 'self_report';
                   
                     return (
@@ -149,11 +160,13 @@ const IncidentList = (props) => {
                         <Card className="border-0 shadow-sm mx-0">
                         <CardBody className="p-0">
                             {/* Source Tag */}
+                        {props.showSelfReport && (
                         <div>
                             <span className={`source-tag ${isUserReport ? 'user-report' : 'news-report'}`}>
                                 {isUserReport ? 'User Reported' : 'News Reported'}
                             </span>
                         </div>
+                    )}
                             <a className='incident-title'
                                 onClick={() => {
                                 setModalData(d);
@@ -191,10 +204,10 @@ const IncidentList = (props) => {
                     <div className="incident-divider" />
                     </div>
                     )
-                }
-                        return "";
+              
                     })
                 }
+
             </div>
             <Modal
                 isOpen={modalIsOpen}


### PR DESCRIPTION
This update adds initial support for displaying media in the IncidentList.
The modal implementation will be included in the next PR, as that change is larger and requires more restructuring.

### For testing purposes:
**Please update line 133 and line 143 to replace "approved" with "new" in home.js**, since the current test data that contains image is labeled as "new" and not "approved".

### What’s included in this PR:

- Each incident row now displays 3–4 preview images (when available).
- When the Show Self-report Incident toggle is on, each incident show show the source tag to distinguish user report and news report. When toggle off, there is no source tag

### Tests:
<img width="1458" height="863" alt="Screenshot 2025-11-14 at 12 29 05 PM" src="https://github.com/user-attachments/assets/6c4c7e37-a196-442b-9144-e29f6db9c48a" /> <br>

<img width="432" height="743" alt="Screenshot 2025-11-14 at 12 29 47 PM" src="https://github.com/user-attachments/assets/bb34addb-57d5-4dc6-9891-1a00821b3c0c" /> <br>


https://github.com/user-attachments/assets/a7d9a7d3-f651-4f20-a65d-18296d7072cb



