### PR TITLE
Fix React 18 head meta tag rendering issue

### DIFF
--- a/src/views/components/head.js
+++ b/src/views/components/head.js
@@ -1,32 +1,50 @@
-import React from 'react'
-import MetaTags from 'react-meta-tags'
-const site_desc = "Even though the anti-Asian hate is not under the spotlight in today’s news, the violence and hate is still happening on a daily basis. hatecrimetracker.1thing.org collects and visualizes all anti-Asian hate incidents reported by the media.";
-const site_title = "Anti-Asian Hate Crime Tracker";
-const site_url = "https://hatecrimetracker.1thing.org";
+import { useEffect } from 'react'
+
+// Native replacement for react-meta-tags, which uses the React-18-deprecated
+// ReactDOM.render API and throws `Failed to execute 'removeChild' on 'Node'`
+// during commit when it has children to render.
+
+const SITE_DESC = "Even though the anti-Asian hate is not under the spotlight in today’s news, the violence and hate is still happening on a daily basis. hatecrimetracker.1thing.org collects and visualizes all anti-Asian hate incidents reported by the media.";
+const SITE_TITLE = "Anti-Asian Hate Crime Tracker";
+const SITE_URL = "https://hatecrimetracker.1thing.org";
+
+const META_TAGS = [
+    { attrs: { charset: 'UTF-8' } },
+    { attrs: { name: 'viewport', content: 'width=device-width, initial-scale=1' } },
+    { attrs: { name: 'type', property: 'og:type', content: 'website' } },
+    { attrs: { name: 'title', property: 'og:title', content: SITE_TITLE } },
+    { attrs: { name: 'site_name', property: 'og:site_name', content: SITE_TITLE } },
+    { attrs: { name: 'keywords', content: SITE_TITLE } },
+    { attrs: { name: 'url', property: 'og:url', content: SITE_URL } },
+    { attrs: { name: 'image', property: 'og:image', content: SITE_URL + '/images/hatecrimetracker_image.png' } },
+    { attrs: { name: 'description', property: 'og:description', content: SITE_DESC } },
+    { attrs: { name: 'twitter:card', content: 'Anti-Asian Hate Crime Trend' } },
+    { attrs: { name: 'twitter:site', content: SITE_URL } },
+    { attrs: { name: 'twitter:creator', content: '@1Thing_Org' } },
+    { attrs: { name: 'twitter:title', content: SITE_TITLE } },
+    { attrs: { name: 'twitter:description', content: SITE_DESC } },
+    { attrs: { name: 'twitter:image', content: SITE_URL + '/images/hatecrimetracker_twitter.png' } },
+];
+
 const Head = () => {
-    return (
-        <div className='wrapper'>
-            <MetaTags>
-                <meta charSet='UTF-8' />
-                <meta name='viewport' content='width=device-width, initial-scale=1' />
-                <title>{site_title}</title>
-                <meta name='type' property='og:type' content='website' />
-                <meta name='title' property='og:title' content={site_title} />
-                <meta name='site_name' property='og:site_name' content={site_title} />
-                <meta name='keywords' content={site_title} />
-                <meta name='url' property='og:url' content={site_url} />
-                <meta name="image" property='og:image' content={site_url + '/images/hatecrimetracker_image.png'} />
-                <meta name="description" property='og:description' content={site_desc} />
+    useEffect(() => {
+        const previousTitle = document.title;
+        document.title = SITE_TITLE;
 
-                <meta name="twitter:card" content="Anti-Asian Hate Crime Trend" />
-                <meta name="twitter:site" content={site_url} />
-                <meta name="twitter:creator" content="@1Thing_Org" />
-                <meta name="twitter:title" content={site_title} />
-                <meta name="twitter:description" content={site_desc} />
-                <meta name="twitter:image" content={site_url + "/images/hatecrimetracker_twitter.png"} />
-            </MetaTags>
-        </div>
-    )
-}
+        const elements = META_TAGS.map(({ attrs }) => {
+            const el = document.createElement('meta');
+            Object.entries(attrs).forEach(([key, value]) => el.setAttribute(key, value));
+            document.head.appendChild(el);
+            return el;
+        });
 
-export default Head
+        return () => {
+            document.title = previousTitle;
+            elements.forEach((el) => el.parentNode && el.parentNode.removeChild(el));
+        };
+    }, []);
+
+    return null;
+};
+
+export default Head;


### PR DESCRIPTION
## Problems

The previous implementation used `react-meta-tags`, which internally relies on `ReactDOM.render`. This is incompatible with React 18 and can trigger the following runtime error during re-renders.

**In production,** the live site can still render, but the error appears in the browser console. This may create noisy runtime errors and could become more problematic with future React upgrades.

<img width="1293" height="761" alt="image" src="https://github.com/user-attachments/assets/d2dcb328-ac2d-4b86-a19f-75944c494359" />

**In local development,** the same error blocks rendering and is shown directly by the React error overlay.
<img width="2878" height="1590" alt="88705ea744b8d4e472e0c09c41035209" src="https://github.com/user-attachments/assets/21727a4a-1b09-4764-a9c3-f859d7cd55ef" />

## Solution

This PR replaces `react-meta-tags` with native DOM-based updates in `head.js`.

The new implementation updates `document.title` and appends the required SEO, Open Graph, and Twitter meta tags directly to `document.head`, avoiding the deprecated `ReactDOM.render` path used by `react-meta-tags`.

## After fix 
The local can render normally
<img width="2950" height="1638" alt="9031d5c02fcad3fd3c25c6eb571ff1a1" src="https://github.com/user-attachments/assets/9bfd08ac-af5d-4a67-a369-5738f8364e03" />
